### PR TITLE
Add support for Ollama with target file example for Llama 3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ langchain-together
 langchain-groq
 langchain-aws
 langchain-huggingface
+langchain-ollama
 tabulate
 jinja2
 pandas

--- a/spikee/targets/ollama_llama32.py
+++ b/spikee/targets/ollama_llama32.py
@@ -1,0 +1,30 @@
+import os
+from langchain_ollama import ChatOllama
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+llm = ChatOllama(
+    model="llama3.2",
+    max_tokens=None,
+    timeout=None,
+    max_retries=2,
+)
+
+def process_input(input_text, system_message=None):
+    messages = []
+    # system message not supported by o1 models at this time
+    # so we just add the system message at the beginning
+    prompt = input_text
+    if system_message:
+       prompt = f"{system_message}\n{input_text}"
+
+    messages.append(("user", prompt))
+    
+    try:
+        ai_msg = llm.invoke(messages)
+        return ai_msg.content
+    except Exception as e:
+        print(f"Error during LLM completion: {e}")
+        raise


### PR DESCRIPTION
- modified requirements.txt file to include 'langchain-ollama'
- added in Ollama target with an example for Llama 3.2 model